### PR TITLE
missing return statement

### DIFF
--- a/src/ValidatorErrorIterator.php
+++ b/src/ValidatorErrorIterator.php
@@ -46,6 +46,8 @@ class ValidatorErrorIterator extends ErrorIterator
         $this->withPointers(
             fn($key) => sprintf('%s/%s', $prefix, $this->convertKey($key))
         );
+        
+        return $this;
     }
 
     /**


### PR DESCRIPTION
I think you guys missing return statement here

```
   /**
     * Use the prefix when converting keys.
     *
     * @param string $prefix
     * @return $this
     */
    public function withSourcePrefix(string $prefix): self
    {
        $prefix = rtrim($prefix, '/');

        $this->withPointers(
            fn($key) => sprintf('%s/%s', $prefix, $this->convertKey($key))
        );
    }
```

![image](https://user-images.githubusercontent.com/67781184/122755115-b9566c00-d2be-11eb-9e34-d811de024840.png)
