### PR TITLE
[BugFix] Double Slash when using withSourcePrefix method

### DIFF
--- a/src/ValidatorErrorIterator.php
+++ b/src/ValidatorErrorIterator.php
@@ -41,10 +41,10 @@ class ValidatorErrorIterator extends ErrorIterator
      */
     public function withSourcePrefix(string $prefix): self
     {
-        $prefix = rtrim($prefix, '/');
+        $prefix = trim($prefix, '/');
 
         $this->withPointers(
-            fn($key) => sprintf('%s/%s', $prefix, $this->convertKey($key))
+            fn($key) => sprintf('/%s%s', $prefix, $this->convertKey($key))
         );
         
         return $this;


### PR DESCRIPTION
#4 

```
public function withSourcePrefix(string $prefix): self
    {
        $prefix = rtrim($prefix, '/');

        $this->withPointers(
            fn($key) => sprintf('%s/%s', $prefix, $this->convertKey($key))
        );
        
        return $this;
    }
```

```
protected function convertKey(string $key): string
    {
        return '/' . str_replace('.', '/', $key);
    }
```

Fix with

```
public function withSourcePrefix(string $prefix): self
    {
        $prefix = rtrim($prefix, '/');

        $this->withPointers(
            fn($key) => sprintf('%s%s', $prefix, $this->convertKey($key))
        );
        
        return $this;
    }
```

