### PR TITLE
fix: change param typing for allowed check in AbstractAllowedRule

### DIFF
--- a/src/Rules/AbstractAllowedRule.php
+++ b/src/Rules/AbstractAllowedRule.php
@@ -147,10 +147,10 @@ abstract class AbstractAllowedRule implements Rule
     /**
      * Is the parameter allowed?
      *
-     * @param string $param
+     * @param mixed $param
      * @return bool
      */
-    protected function allowed(string $param): bool
+    protected function allowed(mixed $param): bool
     {
         return $this->allowed->has($param);
     }


### PR DESCRIPTION
This PR propose to change the `AbstractAllowedRule::allowed` method parameter typing from `string` to `mixed`.

# Why

When using laravel-json-api/laravel, calling the following endpoint with default pagination will throw an error:

```
https://example.com/api/v1/posts?page=1
```

And the error will be thrown even if we are validating the page param before applying the `AllowedPageParameters` rule. This is because Laravel will evaluate every rule, even when previous failed. Here is an example of my validation rules for pagination:

```php
use LaravelJsonApi\Validation\Rule as JsonApiRule;

return [
    'page'        => ['required', 'array:number,size', JsonApiRule::page()],
    'page.number' => ['filled', 'integer', 'min:1'],
    'page.size'   => ['filled', 'integer', 'min:1', 'max:100'],
];
```

This problem may apply to any "collected" and array expected param (filter, fields, etc.).

# Solution

Using the `mixed` type on it won't give false positive (as we are checking using the allowed collection `has` method). In case PHP type conversion may be a problem, we could perform an additional [`is_string`](https://www.php.net/manual/function.is-string.php) method to force strict comparison.

# Impacts

As we are changing the `allowed` method signature, projects which are extending the class and method will get errors because of the method signature mismatch.

# Other solutions

Another solution is to better extract the values for those array typed params (with `is_array` check) as it is done through `is_string` inside AllowedIncludePaths rule.