### PR TITLE
Bugfix: use `array_shift` in error iterator instead of Laravel collection method

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,9 @@ name: Tests
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main, develop, 3.x ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ main, develop, 3.x ]
 
 jobs:
   build:
@@ -14,12 +14,12 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.1, 8.2]
+        php: [8.1, 8.2, 8.3]
         laravel: [10]
 
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
@@ -34,7 +34,7 @@ jobs:
       run: composer require "illuminate/contracts:^${{ matrix.laravel }}" --no-update
 
     - name: Install dependencies
-      uses: nick-fields/retry@v2
+      uses: nick-fields/retry@v3
       with:
         timeout_minutes: 5
         max_attempts: 5

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor/
 composer.lock
 .phpunit.result.cache
+.phpunit.cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file. This projec
 
 ## Unreleased
 
+## [3.0.1] - 2024-06-20
+
 ### Fixed
 
 - [laravel#287](https://github.com/laravel-json-api/laravel/issues/287) Use `array_shift` to avoid potential problem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file. This project adheres to
 [Semantic Versioning](http://semver.org/) and [this changelog format](http://keepachangelog.com/).
 
+## Unreleased
+
+### Fixed
+
+- [laravel#287](https://github.com/laravel-json-api/laravel/issues/287) Use `array_shift` to avoid potential problem
+  introduced in Laravel.
+
 ## [3.0.0] - 2023-02-14
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file. This projec
 
 ## Unreleased
 
+## [4.1.1] - 2024-06-20
+
 ### Fixed
 
 - [laravel#287](https://github.com/laravel-json-api/laravel/issues/287) Use `array_shift` to avoid potential problem

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-develop": "3.x-dev"
+            "dev-3.x": "3.x-dev"
         },
         "laravel": {
             "providers": [

--- a/src/ErrorIterator.php
+++ b/src/ErrorIterator.php
@@ -114,13 +114,15 @@ abstract class ErrorIterator implements IteratorAggregate, Countable, Serializab
         $failed = $this->failed();
 
         foreach ($this->validator->errors()->messages() as $key => $messages) {
-            $failures = $this->translator->validationFailures($failed[$key] ?? []);
+            $failures = $this->translator
+                ->validationFailures($failed[$key] ?? [])
+                ->all();
 
             foreach ($messages as $message) {
                 yield $this->createError(
                     $key,
                     $message,
-                    $failures->shift() ?: []
+                    array_shift($failures) ?: [],
                 );
             }
         }


### PR DESCRIPTION
This brings in the fix tagged as `v3.0.1`.

See https://github.com/laravel-json-api/laravel/issues/287